### PR TITLE
Use 401 for authentication failures

### DIFF
--- a/restapi.module
+++ b/restapi.module
@@ -255,7 +255,7 @@ function restapi_delivery_callback($response) {
       // requests, this is assumed to be an authentication check.
       case MENU_ACCESS_DENIED:
         $error   = 'unauthenticated';
-        $status  = 403;
+        $status  = 401;
         $message = t('Your credentials could not be verified.');
         break;
 


### PR DESCRIPTION
restapi makes the assumption that all menu access failures are auth failures, so that should be reflected in the code it sends in the response.