### PR TITLE
Let authentication service to determine the user and propagate any exceptions

### DIFF
--- a/restapi.module
+++ b/restapi.module
@@ -25,8 +25,8 @@ function restapi_menu() {
 
     $items[$resource->getPath()] = [
       'page callback'     => 'restapi_page_callback',
-      'access callback'   => 'restapi_access_callback',
-      'access arguments'  => [$resource],
+      'page arguments'    => [$resource],
+      'access callback'   => TRUE,
       'delivery callback' => 'restapi_delivery_callback',
       'type'              => MENU_CALLBACK,
     ];
@@ -218,39 +218,33 @@ function restapi_watchdog_alter(&$log_entry) {
 /**
  * Page callback to handle an API call from the Drupal menu system.
  *
- * @return JsonResponse
- *
- */
-function restapi_page_callback() {
-
-  global $user;
-
-  $request = restapi_get_request();
-  $api     = new Api($user, $request);
-
-  return $api->call($request->getMethod(), current_path());
-
-}
-
-
-/**
- * Handles the authentication.
- *
  * @param ResourceConfiguration $resource
  *   The resource that is being accessed, as defined in restapi_get_resources().
  *
- * @return boolean
+ * @return JsonResponse
  *
  */
-function restapi_access_callback(ResourceConfiguration $resource) {
+function restapi_page_callback(ResourceConfiguration $resource) {
 
   global $user;
 
   $request = restapi_get_request();
   $auth    = $resource->invokeAuthenticationService($user, $request);
 
-  return $auth->isValid();
+  try {
+    $account = $auth->authenticate();
+  }
+  catch (Exception $e) {
+    return restapi_invoke_hook_exception($e);
+  }
 
+  if (!$account) {
+    return MENU_ACCESS_DENIED;
+  }
+
+  $api = new Api($account, $request);
+
+  return $api->call($request->getMethod(), current_path());
 }
 
 
@@ -555,4 +549,30 @@ function restapi_get_url_prefix() {
   // If a URL prefix is set, and not included in the path, add it.
   $prefix = variable_get('restapi_url_prefix');
   return rtrim(ltrim(trim($prefix), '/'), '/');
+}
+
+
+/**
+ * Helper function to invoke hook_restapi_exception.
+ *
+ * @param Exception $e
+ *   The exception that is being thrown.
+ *
+ * @return ResponseInterface|NULL
+ *
+ */
+function restapi_invoke_hook_exception(Exception $e) {
+
+  $response = NULL;
+
+  foreach(module_implements('restapi_exception') as $module) {
+    $func   = $module . '_restapi_exception';
+    $result = $func($e, $response);
+
+    if ($result instanceof ResponseInterface) {
+      $response = $result;
+    }
+  }
+
+  return $response;
 }

--- a/src/Api.php
+++ b/src/Api.php
@@ -171,7 +171,7 @@ class Api {
     }
     catch (Exception $e) {
 
-      $response = $this->invokeHookException($e);
+      $response = restapi_invoke_hook_exception($e);
 
       if (!$response) {
         $response = $this->toError($e->getMessage());
@@ -342,32 +342,6 @@ class Api {
     foreach(module_implements('restapi_response') as $module) {
       $func   = $module . '_restapi_response';
       $result = $func($path, $resource, $request, $response);
-
-      if ($result instanceof ResponseInterface) {
-        $response = $result;
-      }
-    }
-
-    return $response;
-  }
-
-
-  /**
-   * Helper method to invoke hook_restapi_exception.
-   *
-   * @param Exception $e
-   *   The exception that is being thrown.
-   *
-   * @return ResponseInterface|NULL
-   *
-   */
-  protected function invokeHookException(Exception $e) {
-
-    $response = NULL;
-
-    foreach(module_implements('restapi_exception') as $module) {
-      $func   = $module . '_restapi_exception';
-      $result = $func($e, $response);
 
       if ($result instanceof ResponseInterface) {
         $response = $result;

--- a/src/Auth/AbstractAuthenticationService.php
+++ b/src/Auth/AbstractAuthenticationService.php
@@ -42,7 +42,7 @@ abstract class AbstractAuthenticationService implements AuthenticationServiceInt
    * {@inheritdoc}
    *
    */
-  abstract public function isValid();
+  abstract public function authenticate();
 
 
   /**

--- a/src/Auth/AuthenticationServiceInterface.php
+++ b/src/Auth/AuthenticationServiceInterface.php
@@ -24,11 +24,12 @@ interface AuthenticationServiceInterface {
 
 
   /**
-   * Determines if the request is valid or not.
+   * Authenticates the request.
    *
-   * @return boolean
+   * @return \StdClass|FALSE
+   *   If successful, the user the request authenticated for; FALSE otherwise.
    *
    */
-  public function isValid();
+  public function authenticate();
 
 }

--- a/src/Auth/DrupalAuthenticationService.php
+++ b/src/Auth/DrupalAuthenticationService.php
@@ -14,8 +14,16 @@ class DrupalAuthenticationService extends AbstractAuthenticationService {
    * {@inheritdoc}
    *
    */
-  public function isValid() {
-    return user_access('access content', $this->getUser());
+  public function authenticate() {
+    if (!user_is_logged_in()) {
+      return FALSE;
+    }
+
+    if (!user_access('access content', $this->getUser())) {
+      return FALSE;
+    }
+
+    return $this->getUser();
   }
 
 }


### PR DESCRIPTION
Currently, restapi relies on Drupal's menu router system to handle access checks to resources. This is somewhat limiting because it only supports a boolean check: either the resource can be accessed or not.

However, REST APIs generally support a richer authentication system: if an authentication check fails, there may be multiple possible reasons. And if an authentication check succeeds, the authentication header may specify who, exactly, the check succeeded for.

This PR bypasses Drupal's menu access system and lets restapi fully handle the authentication. This allows exceptions in `AuthenticationServiceInterface` to be handled as responses in the same way that the rest of a request is handled. This allows authentication services to specify the exact reason why an authentication check failed.

Additionally, `AuthenticationServiceInterface::isValid()` has been replaced with `AuthenticationServiceInterface::authenticate`, which will return the authenticated user if the authentication succeeds.