### PR TITLE
Ensure parsed request body is always an array

### DIFF
--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -56,7 +56,7 @@ class ServerRequestFactory extends AbstractServerRequestFactory {
       $new  = [];
 
       if ($is_json) {
-        $new = json_decode($data, TRUE);
+        $new = (array) json_decode($data, TRUE);
       } else {
         parse_str($data, $new);
       }

--- a/tests/ServerRequestFactoryTest.php
+++ b/tests/ServerRequestFactoryTest.php
@@ -40,10 +40,10 @@ class ServerRequestFactoryTest extends PHPUnit_Framework_TestCase {
 
   /**
    * Ensures that fromGlobals() results in JsonRequest::parsedBody() being set
-   * when given a JSON string as PHP input.
+   * correctly when given a non-scalar JSON string as PHP input.
    *
    */
-  public function testJsonStringIsSetAsParsedData() {
+  public function testNonScalarJsonStringIsSetAsParsedData() {
 
     $server = [
       'CONTENT_TYPE' => 'application/json',
@@ -54,6 +54,33 @@ class ServerRequestFactoryTest extends PHPUnit_Framework_TestCase {
     $expected = [
       'test' => 'testing',
     ];
+
+    $request = ServerRequestFactory::fromGlobals($server, null, null, null, null, $content);
+    $this->assertEquals($expected, $request->getParsedBody());
+  }
+
+
+  /**
+   * Ensures that fromGlobals() results in JsonRequest::parsedBoyd() being set
+   * correctly when given a scalar JSON string as PHP input.
+   *
+   */
+  public function testScalarJsonStringIsSetAsParsedData() {
+
+    $server = [
+      'CONTENT_TYPE' => 'application/json',
+      'REQUEST_METHOD' => 'POST',
+    ];
+
+    $content = new Stream('data://text/plain,null');
+    $expected = [];
+
+    $request = ServerRequestFactory::fromGlobals($server, null, null, null, null, $content);
+    $this->assertEquals($expected, $request->getParsedBody());
+
+
+    $content = new Stream('data://text/plain,"test"');
+    $expected = ['test'];
 
     $request = ServerRequestFactory::fromGlobals($server, null, null, null, null, $content);
     $this->assertEquals($expected, $request->getParsedBody());


### PR DESCRIPTION
`json_decode(..., TRUE)` is not guaranteed to return an array: it can return a scalar if the JSON string is a scalar or if it can't parse the JSON string. When this happens, L65 in `SeverRequestFactory` will emit a warning about attempting to merge a non-array.

This PR addresses this by casting the result of `json_decode()` to an array. Result table:

| $data             | json_decode($data, TRUE)           | $new  |
| ------------- | -------------------------------- | ------- |
| `'null'`               | `null`                                                  | `[]` |
| `'false'`             | `false`                                                | `[false]` |
| `'"test"'`            | `'test'`                                               | `['test']` |