### PR TITLE
Add default OPTIONS handling with Allow: header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: php
 
 php:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_script:
   - travis_retry composer install --no-interaction
 
 script:
-  - phpunit --coverage-text --coverage-clover=coverage.clover
+  - ./vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover

--- a/src/AbstractResource.php
+++ b/src/AbstractResource.php
@@ -4,6 +4,7 @@ namespace Drupal\restapi;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Zend\Diactoros\Response\EmptyResponse;
 
 
 /**
@@ -86,6 +87,30 @@ abstract class AbstractResource implements ResourceInterface {
    *
    */
   public function after(ResponseInterface $response) {}
+
+
+  /**
+   * Default OPTIONS handler.
+   *
+   */
+  public function options() {
+
+    $possible_methods = ['DELETE', 'GET', 'POST', 'PUT', 'OPTIONS'];
+    $request          = $this->getRequest();
+    $path             = $request->getUri()->getPath();
+    $resource         = restapi_get_resource($path);
+
+    // Check to see if there's a versioned class method for each possible HTTP verb
+    $allowed_methods = array_filter($possible_methods, function ($method) use ($request, $resource) {
+      return _restapi_get_versioned_method($resource, $request->withMethod($method));
+    });
+
+    $headers['Allow'] = implode(', ', $allowed_methods);
+
+    // @todo add support for CORS preflight headers
+
+    return new EmptyResponse(200, $headers);
+  }
 
 
   /**


### PR DESCRIPTION
Adds a default OPTIONS handler to resources that sets the Allow: header with what methods are available to the resource.