### PR TITLE
Improve content negotiation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "license": "MIT",
     "require": {
         "php": "~5.6",
+        "willdurand/negotiation": "~2.3.1",
         "zendframework/zend-diactoros": "~1.1.0"
     },
     "require-dev": {

--- a/restapi.module
+++ b/restapi.module
@@ -3,6 +3,7 @@
 use Drupal\restapi\Api;
 use Drupal\restapi\JsonRequest;
 use Drupal\restapi\JsonResponse;
+use Negotiation\Negotiator;
 use Psr\Http\Message\ResponseInterface;
 use Drupal\restapi\ServerRequestFactory;
 use Drupal\restapi\ResourceConfiguration;
@@ -221,9 +222,10 @@ function restapi_restapi_exception(Exception $e, ResponseInterface $response = N
  */
 function restapi_theme_registry_alter(&$theme) {
 
-  $request = restapi_get_request();
+  $request    = restapi_get_request();
+  $negotiator = new Negotiator();
 
-  if ($request->isJson()) {
+  if ($negotiator->getBest($request->getHeaderLine('Accept'), ['application/json'])) {
     $file = 'restapi.theme.inc';
     $path = drupal_get_path('module', 'restapi');
 
@@ -272,8 +274,9 @@ function restapi_page_callback(ResourceConfigurationInterface $resource) {
 
   global $user;
 
-  $request = restapi_get_request();
-  $auth    = $resource->invokeAuthenticationService($user, $request);
+  $request    = restapi_get_request();
+  $negotiator = new Negotiator();
+  $auth       = $resource->invokeAuthenticationService($user, $request);
 
   try {
     $account = $auth->authenticate();
@@ -286,7 +289,7 @@ function restapi_page_callback(ResourceConfigurationInterface $resource) {
     return MENU_ACCESS_DENIED;
   }
 
-  $api = new Api($account, $request);
+  $api = new Api($account, $negotiator, $request);
 
   return $api->call($request->getMethod(), current_path());
 }
@@ -374,10 +377,13 @@ function restapi_delivery_callback($response) {
 
   // For requests in the browser, we'll try to show the output in a more
   // pleasant way.
-  if (!$request->isJson() &&
-      strpos($response->getHeaderLine('content-type'), 'application/json') !== FALSE &&
-      strpos($request->getHeaderLine('Accept'), 'text/html') !== FALSE) {
-    return restapi_deliver_html($response);
+  $negotiator = new Negotiator();
+  $accept     = $request->getHeaderLine('Accept');
+  $priorities = ['application/json', 'text/html'];
+
+  if ($negotiator->getBest($accept, $priorities) === 'text/html') {
+    restapi_deliver_html($response);
+    return;
   }
 
   (new SapiEmitter())->emit($response);

--- a/src/Api.php
+++ b/src/Api.php
@@ -151,9 +151,11 @@ class Api {
     }
 
     // Check to see if this request requires a version.
-    $accept_header   = $request->getHeaderLine('Accept');
-    $versioned_types = $resource->getVersionedTypes();
-    if ($accept_header && $versioned_types && $this->negotiator->getBest($accept_header, $versioned_types) && !$request->getVersion()) {
+    $accept_header    = $request->getHeaderLine('Accept');
+    $versioned_types  = $resource->getVersionedTypes();
+    $should_negotiate = $accept_header && $versioned_types && !$request->getVersion();
+
+    if ($should_negotiate && $this->negotiator->getBest($accept_header, $versioned_types)) {
       return $this->toError(t('Missing required API version number.'), 'missing_version', 400);
     }
 

--- a/src/Api.php
+++ b/src/Api.php
@@ -7,6 +7,7 @@ use Drupal\restapi\Exception\MissingParametersException;
 use Drupal\restapi\Exception\RestApiException;
 use Drupal\restapi\Exception\UnauthorizedException;
 use Exception;
+use Negotiation\Negotiator;
 use Psr\Http\Message\ResponseInterface;
 
 
@@ -34,23 +35,35 @@ class Api {
 
 
   /**
+   * The content type negotiator.
+   *
+   * @var Negotiator
+   *
+   */
+  protected  $negotiator;
+
+
+  /**
    * Constructor
    *
    * @param \StdClass $user
    *   The Drupal user to call this resource as. Defaults to the current user.
+   * @param Negotiator $negotiator
+   *   The content type negotiator.
    * @param JsonRequest $request
    *   The request to use to set the context for the resource. Defaults to the
    *   current page request.
    *
    */
-  public function __construct(\StdClass $user = NULL, JsonRequest $request = NULL) {
+  public function __construct(\StdClass $user = NULL, Negotiator $negotiator, JsonRequest $request = NULL) {
 
     if (!$request) {
       $request = ServerRequestFactory::fromGlobals();
     }
 
-    $this->request = $request;
-    $this->user = $user ?: $GLOBALS['user'];
+    $this->negotiator = $negotiator;
+    $this->request    = $request;
+    $this->user       = $user ?: $GLOBALS['user'];
   }
 
 
@@ -138,13 +151,12 @@ class Api {
     }
 
     // Check to see if this request requires a version.
-    foreach ($resource->getVersionedTypes() as $type) {
-
-      if (strpos($request->getHeaderLine('accept'), $type) !== FALSE && !$request->getVersion()) {
-        return $this->toError(t('Missing required API version number.'), 'missing_version', 400);
-      }
-
+    $accept_header   = $request->getHeaderLine('Accept');
+    $versioned_types = $resource->getVersionedTypes();
+    if ($accept_header && $versioned_types && $this->negotiator->getBest($accept_header, $versioned_types) && !$request->getVersion()) {
+      return $this->toError(t('Missing required API version number.'), 'missing_version', 400);
     }
+
 
     $versioned_method = _restapi_get_versioned_method($resource, $request);
 

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -8,13 +8,14 @@ class ApiTest extends PHPUnit_Framework_TestCase {
 
   public function setUp() {
 
+    $this->negotiator = $this->createMock('Negotiation\Negotiator');
     $this->request = $this->createMock('Drupal\restapi\JsonRequest');
     $this->user = (object) [
       'uid' => 1,
       'name' => 'user',
     ];
 
-    $this->api = new Api($this->user, $this->request);
+    $this->api = new Api($this->user, $this->negotiator, $this->request);
   }
 
 


### PR DESCRIPTION
This introduces a proper content negotiation library to handle situations where restapi needs to determine the correct content type based on priorities (i.e. just looking for a content type in the accept header is not enough).