### PR TITLE
Improve content negotiation support

### DIFF
--- a/restapi.module
+++ b/restapi.module
@@ -675,7 +675,7 @@ function _restapi_get_versioned_method(ResourceConfigurationInterface $resource,
     $version = $current_version > $request->getVersion() ? $request->getVersion() : $current_version;
   }
   else {
-    watchdog('restapi', 'Accept header does not include a requested version, falling back to current version.', WATCHDOG_INFO);
+    watchdog('restapi', 'Accept header does not include a requested version, falling back to current version.', [], WATCHDOG_INFO);
     $version = $current_version;
   }
 

--- a/restapi.module
+++ b/restapi.module
@@ -378,13 +378,18 @@ function restapi_delivery_callback($response) {
 
   // For requests in the browser, we'll try to show the output in a more
   // pleasant way.
-  $negotiator = new Negotiator();
-  $accept     = $request->getHeaderLine('Accept');
-  $priorities = ['application/json', 'text/html'];
+  $accept = $request->getHeaderLine('Accept');
+  if ($accept) {
 
-  if ($accept && $negotiator->getBest($accept, $priorities) === 'text/html') {
-    restapi_deliver_html($response);
-    return;
+    $negotiator = new Negotiator();
+    $priorities = ['application/json', 'text/html'];
+    $best_type  = $negotiator->getBest($accept, $priorities);
+
+    if ($best_type->getValue() === 'text/html') {
+      restapi_deliver_html($response);
+      return;
+    }
+
   }
 
   (new SapiEmitter())->emit($response);
@@ -588,6 +593,7 @@ function restapi_execute_resource($method, $path, array $data = [], array $heade
 
   $path  = ltrim(trim($path), '/');
   $prefix = restapi_get_url_prefix();
+  $negotiator = new Negotiator();
 
   // If a URL prefix is set, and not included in the path, add it.
   if ($prefix && strpos($prefix, $path) !== 0) {
@@ -596,7 +602,7 @@ function restapi_execute_resource($method, $path, array $data = [], array $heade
 
   $request = $request ?: restapi_get_request();
   $user    = $user ?: $GLOBALS['user'];
-  $api     = new Api($user, $request);
+  $api     = new Api($user, $negotiator, $request);
   $headers = $headers ?: ['Accept' => 'application/json; version=' . variable_get('restapi_current_version', 1)];
 
   return $api->call($method, $path, $data, $headers);

--- a/restapi.module
+++ b/restapi.module
@@ -275,9 +275,8 @@ function restapi_page_callback(ResourceConfigurationInterface $resource) {
 
   global $user;
 
-  $request    = restapi_get_request();
-  $negotiator = new Negotiator();
-  $auth       = $resource->invokeAuthenticationService($user, $request);
+  $request = restapi_get_request();
+  $auth    = $resource->invokeAuthenticationService($user, $request);
 
   try {
     $account = $auth->authenticate();
@@ -290,7 +289,7 @@ function restapi_page_callback(ResourceConfigurationInterface $resource) {
     return MENU_ACCESS_DENIED;
   }
 
-  $api = new Api($account, $negotiator, $request);
+  $api = new Api($account, $request);
 
   return $api->call($request->getMethod(), current_path());
 }
@@ -593,7 +592,6 @@ function restapi_execute_resource($method, $path, array $data = [], array $heade
 
   $path  = ltrim(trim($path), '/');
   $prefix = restapi_get_url_prefix();
-  $negotiator = new Negotiator();
 
   // If a URL prefix is set, and not included in the path, add it.
   if ($prefix && strpos($prefix, $path) !== 0) {
@@ -602,7 +600,7 @@ function restapi_execute_resource($method, $path, array $data = [], array $heade
 
   $request = $request ?: restapi_get_request();
   $user    = $user ?: $GLOBALS['user'];
-  $api     = new Api($user, $negotiator, $request);
+  $api     = new Api($user, $request);
   $headers = $headers ?: ['Accept' => 'application/json; version=' . variable_get('restapi_current_version', 1)];
 
   return $api->call($method, $path, $data, $headers);
@@ -677,6 +675,7 @@ function _restapi_get_versioned_method(ResourceConfigurationInterface $resource,
     $version = $current_version > $request->getVersion() ? $request->getVersion() : $current_version;
   }
   else {
+    watchdog('restapi', 'Accept header does not include a requested version, falling back to current version.', WATCHDOG_INFO);
     $version = $current_version;
   }
 

--- a/src/Api.php
+++ b/src/Api.php
@@ -35,35 +35,23 @@ class Api {
 
 
   /**
-   * The content type negotiator.
-   *
-   * @var Negotiator
-   *
-   */
-  protected  $negotiator;
-
-
-  /**
    * Constructor
    *
    * @param \StdClass $user
    *   The Drupal user to call this resource as. Defaults to the current user.
-   * @param Negotiator $negotiator
-   *   The content type negotiator.
    * @param JsonRequest $request
    *   The request to use to set the context for the resource. Defaults to the
    *   current page request.
    *
    */
-  public function __construct(\StdClass $user = NULL, Negotiator $negotiator, JsonRequest $request = NULL) {
+  public function __construct(\StdClass $user = NULL, JsonRequest $request = NULL) {
 
     if (!$request) {
       $request = ServerRequestFactory::fromGlobals();
     }
 
-    $this->negotiator = $negotiator;
-    $this->request    = $request;
-    $this->user       = $user ?: $GLOBALS['user'];
+    $this->request = $request;
+    $this->user    = $user ?: $GLOBALS['user'];
   }
 
 
@@ -149,16 +137,6 @@ class Api {
     foreach ($headers as $key => $value) {
       $request = $request->withHeader($key, $value);
     }
-
-    // Check to see if this request requires a version.
-    $accept_header    = $request->getHeaderLine('Accept');
-    $versioned_types  = $resource->getVersionedTypes();
-    $should_negotiate = $accept_header && $versioned_types && !$request->getVersion();
-
-    if ($should_negotiate && $this->negotiator->getBest($accept_header, $versioned_types)) {
-      return $this->toError(t('Missing required API version number.'), 'missing_version', 400);
-    }
-
 
     $versioned_method = _restapi_get_versioned_method($resource, $request);
 

--- a/src/JsonRequest.php
+++ b/src/JsonRequest.php
@@ -60,20 +60,18 @@ class JsonRequest extends ServerRequest {
   /**
    * Returns the API version.
    *
-   * @return int $version
-   *   The version number of the API (default: 1).
+   * @return int|NULL $version
+   *   The requested version number of the API, or NULL if it can't be determined.
    *
    */
   public function getVersion() {
 
     // We'll assume the first accept header to have a version is accurate.
-    preg_match('/application\/json[a-zA-Z ,*.\/]*;\s+version=(\d+)/i', $this->getHeaderLine('accept'), $matches);
+    preg_match('/\s*version=(\d+)?/', $this->getHeaderLine('accept'), $matches);
 
     if (isset($matches[1]) && (int) $matches[1] > 0) {
       return (int) $matches[1];
     }
-
-    return 1;
   }
 
 

--- a/src/JsonRequest.php
+++ b/src/JsonRequest.php
@@ -67,7 +67,7 @@ class JsonRequest extends ServerRequest {
   public function getVersion() {
 
     // We'll assume the first accept header to have a version is accurate.
-    preg_match('/\s*version=(\d+)?/', $this->getHeaderLine('accept'), $matches);
+    preg_match('/;\s*version=(\d+)/', $this->getHeaderLine('accept'), $matches);
 
     if (isset($matches[1]) && (int) $matches[1] > 0) {
       return (int) $matches[1];

--- a/src/JsonRequest.php
+++ b/src/JsonRequest.php
@@ -73,6 +73,8 @@ class JsonRequest extends ServerRequest {
       return (int) $matches[1];
     }
 
+    // Fall back to the current version if the version isn't present in the Accept header.
+    return variable_get('restapi_current_version', 1);
   }
 
 

--- a/src/JsonRequest.php
+++ b/src/JsonRequest.php
@@ -73,8 +73,7 @@ class JsonRequest extends ServerRequest {
       return (int) $matches[1];
     }
 
-    // Fall back to the current version if the version isn't present in the Accept header.
-    return variable_get('restapi_current_version', 1);
+    return 1;
   }
 
 

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -8,14 +8,13 @@ class ApiTest extends PHPUnit_Framework_TestCase {
 
   public function setUp() {
 
-    $this->negotiator = $this->createMock('Negotiation\Negotiator');
     $this->request = $this->createMock('Drupal\restapi\JsonRequest');
     $this->user = (object) [
       'uid' => 1,
       'name' => 'user',
     ];
 
-    $this->api = new Api($this->user, $this->negotiator, $this->request);
+    $this->api = new Api($this->user, $this->request);
   }
 
 

--- a/tests/JsonRequestTest.php
+++ b/tests/JsonRequestTest.php
@@ -161,20 +161,6 @@ class JsonRequestTest extends PHPUnit_Framework_TestCase {
 
 
   /**
-   * Ensures that a version not associated with an application/json accept
-   * header is not used.
-   *
-   */
-  public function testGetVersionIsNullIfAcceptHeaderIsNotJson() {
-
-    $server['HTTP_ACCEPT'] = 'text/html; version=2';
-
-    $request = ServerRequestFactory::fromGlobals($server);
-    $this->assertNull($request->getVersion());
-  }
-
-
-  /**
    * Ensures that isJson() works as expected.
    *
    */


### PR DESCRIPTION
This PR fixes two issues:

- Provides a fallback version if the version can't be retrieved from the `Accept` header.
- Fixes the negotiation API usage so we properly detect if `text/html` is the preferred encoding.