### PR TITLE
Add Allow header on all methods

### DIFF
--- a/restapi.module
+++ b/restapi.module
@@ -152,6 +152,7 @@ function restapi_restapi_response($path, ResourceConfigurationInterface $resourc
   $reflection  = new \ReflectionClass($resource->getClass());
   $method      = _restapi_get_versioned_method($resource, $request);
 
+  // Add deprecation headers.
   $doc_comment = $reflection->hasMethod($method) ? $reflection->getMethod($method)->getDocComment() : '';
   $deprecated  = preg_match('/\* @deprecated\h*[v]?([0-9]+\.[0-9]+)?\h*(.*)$/m', $doc_comment, $matches);
 
@@ -170,13 +171,22 @@ function restapi_restapi_response($path, ResourceConfigurationInterface $resourc
     $response = $response->withHeader('X-' . $api_name . '-Deprecated', implode('; ', $dep_headers));
   }
 
+  // Add debug headers.
   if (variable_get('restapi_debug')) {
     $timer    = timer_stop('restapi-' . $path);
     $response = $response->withHeader('X-Debug-Call-Time', $timer['time'] . 'ms');
   }
 
-  return $response;
+  // Add Allow header by checking to see if there's a versioned class method for
+  // each possible HTTP verb.
+  $possible_methods = ['DELETE', 'GET', 'POST', 'PUT', 'OPTIONS'];
+  $allowed_methods = array_filter($possible_methods, function ($method) use ($request, $resource) {
+    return _restapi_get_versioned_method($resource, $request->withMethod($method));
+  });
 
+  $response = $response->withHeader('Allow', implode(', ', $allowed_methods));
+
+  return $response;
 }
 
 

--- a/src/AbstractResource.php
+++ b/src/AbstractResource.php
@@ -94,22 +94,7 @@ abstract class AbstractResource implements ResourceInterface {
    *
    */
   public function options() {
-
-    $possible_methods = ['DELETE', 'GET', 'POST', 'PUT', 'OPTIONS'];
-    $request          = $this->getRequest();
-    $path             = $request->getUri()->getPath();
-    $resource         = restapi_get_resource($path);
-
-    // Check to see if there's a versioned class method for each possible HTTP verb
-    $allowed_methods = array_filter($possible_methods, function ($method) use ($request, $resource) {
-      return _restapi_get_versioned_method($resource, $request->withMethod($method));
-    });
-
-    $headers['Allow'] = implode(', ', $allowed_methods);
-
-    // @todo add support for CORS preflight headers
-
-    return new EmptyResponse(200, $headers);
+    return new EmptyResponse(200);
   }
 
 


### PR DESCRIPTION
The Allow header should be available on all methods for a resource, not just `OPTIONS`.