### PR TITLE
Avoid overwriting $resource in restapi_page_callback

### DIFF
--- a/restapi.module
+++ b/restapi.module
@@ -289,7 +289,7 @@ function restapi_page_callback(ResourceConfigurationInterface $resource) {
     return MENU_NOT_FOUND;
   }
 
-  $auth     = $resource->invokeAuthenticationService($user, $request);
+  $auth = $resource->invokeAuthenticationService($user, $request);
 
   try {
     $account = $auth->authenticate();

--- a/restapi.module
+++ b/restapi.module
@@ -283,7 +283,6 @@ function restapi_page_callback(ResourceConfigurationInterface $resource) {
 
   $request  = restapi_get_request();
   $path     = current_path();
-  $resource = restapi_get_resource($path);
 
   if (!$resource) {
     return MENU_NOT_FOUND;
@@ -307,7 +306,7 @@ function restapi_page_callback(ResourceConfigurationInterface $resource) {
 
   $api = new Api($account, $request);
 
-  return $api->call($request->getMethod(), current_path());
+  return $api->call($request->getMethod(), $path);
 }
 
 

--- a/restapi.module
+++ b/restapi.module
@@ -281,9 +281,9 @@ function restapi_page_callback(ResourceConfigurationInterface $resource) {
 
   global $user;
 
-  $request  = restapi_get_request();
-  $path     = current_path();
-  $auth     = $resource->invokeAuthenticationService($user, $request);
+  $request = restapi_get_request();
+  $path    = current_path();
+  $auth    = $resource->invokeAuthenticationService($user, $request);
 
   try {
     $account = $auth->authenticate();

--- a/restapi.module
+++ b/restapi.module
@@ -283,12 +283,7 @@ function restapi_page_callback(ResourceConfigurationInterface $resource) {
 
   $request  = restapi_get_request();
   $path     = current_path();
-
-  if (!$resource) {
-    return MENU_NOT_FOUND;
-  }
-
-  $auth = $resource->invokeAuthenticationService($user, $request);
+  $auth     = $resource->invokeAuthenticationService($user, $request);
 
   try {
     $account = $auth->authenticate();

--- a/restapi.module
+++ b/restapi.module
@@ -284,6 +284,11 @@ function restapi_page_callback(ResourceConfigurationInterface $resource) {
   $request  = restapi_get_request();
   $path     = current_path();
   $resource = restapi_get_resource($path);
+
+  if (!$resource) {
+    return MENU_NOT_FOUND;
+  }
+
   $auth     = $resource->invokeAuthenticationService($user, $request);
 
   try {


### PR DESCRIPTION
Just changed to return MENU_NOT_FOUND when the path cant be found.