### PR TITLE
Remove exceptions when trying to add stability and deprecated headers.

### DIFF
--- a/restapi.module
+++ b/restapi.module
@@ -289,7 +289,7 @@ function restapi_page_callback(ResourceConfigurationInterface $resource) {
     return MENU_NOT_FOUND;
   }
 
-  $auth     = $resource->invokeAuthenticationService($user, $request);
+  $auth = $resource->invokeAuthenticationService($user, $request);
 
   try {
     $account = $auth->authenticate();

--- a/restapi.module
+++ b/restapi.module
@@ -283,7 +283,6 @@ function restapi_page_callback(ResourceConfigurationInterface $resource) {
 
   $request  = restapi_get_request();
   $path     = current_path();
-  $resource = restapi_get_resource($path);
 
   if (!$resource) {
     return MENU_NOT_FOUND;
@@ -307,7 +306,7 @@ function restapi_page_callback(ResourceConfigurationInterface $resource) {
 
   $api = new Api($account, $request);
 
-  return $api->call($request->getMethod(), current_path());
+  return $api->call($request->getMethod(), $path);
 }
 
 

--- a/restapi.module
+++ b/restapi.module
@@ -152,17 +152,23 @@ function restapi_restapi_response($path, ResourceConfigurationInterface $resourc
   $api_name = str_replace(' ', '-', variable_get('restapi_api_name', 'API'));
   $method   = _restapi_get_versioned_method($resource, $request);
 
-  if ($deprecation = $resource->getDeprecationForMethod($method)) {
-
-    $dep_parts = ['yes'];
-    $dep_parts[] = 'version=' . ($deprecation['version'] ?: variable_get('restapi_current_version', 1));
-
-    if ($deprecation['reason']) {
-      $dep_parts[] = 'reason=' . $deprecation['reason'];
+    try {
+        $deprecation = $resource->getDeprecationForMethod($method);
+    } catch (ClassMethodNotValidException $e) {
+        $response = $response->withHeader('X-' . $api_name . '-NotValid');
+        return $response;
     }
 
-    $response = $response->withHeader('X-' . $api_name . '-Deprecated', implode('; ', $dep_parts));
-  }
+    if ($deprecation) {
+      $dep_parts = ['yes'];
+      $dep_parts[] = 'version=' . ($deprecation['version'] ?: variable_get('restapi_current_version', 1));
+
+      if ($deprecation['reason']) {
+        $dep_parts[] = 'reason=' . $deprecation['reason'];
+      }
+
+      $response = $response->withHeader('X-' . $api_name . '-Deprecated', implode('; ', $dep_parts));
+    }
 
   $stability = $resource->getStabilityForMethod($method);
   $response  = $response->withHeader('X-' . $api_name . '-Stability', $stability);

--- a/restapi.module
+++ b/restapi.module
@@ -153,6 +153,7 @@ function restapi_restapi_response($path, ResourceConfigurationInterface $resourc
   $method   = _restapi_get_versioned_method($resource, $request);
 
   if ($deprecation = $resource->getDeprecationForMethod($method)) {
+
     $dep_parts = ['yes'];
     $dep_parts[] = 'version=' . ($deprecation['version'] ?: variable_get('restapi_current_version', 1));
 

--- a/restapi.module
+++ b/restapi.module
@@ -152,23 +152,16 @@ function restapi_restapi_response($path, ResourceConfigurationInterface $resourc
   $api_name = str_replace(' ', '-', variable_get('restapi_api_name', 'API'));
   $method   = _restapi_get_versioned_method($resource, $request);
 
-    try {
-        $deprecation = $resource->getDeprecationForMethod($method);
-    } catch (ClassMethodNotValidException $e) {
-        $response = $response->withHeader('X-' . $api_name . '-NotValid');
-        return $response;
+  if ($deprecation = $resource->getDeprecationForMethod($method)) {
+    $dep_parts = ['yes'];
+    $dep_parts[] = 'version=' . ($deprecation['version'] ?: variable_get('restapi_current_version', 1));
+
+    if ($deprecation['reason']) {
+      $dep_parts[] = 'reason=' . $deprecation['reason'];
     }
 
-    if ($deprecation) {
-      $dep_parts = ['yes'];
-      $dep_parts[] = 'version=' . ($deprecation['version'] ?: variable_get('restapi_current_version', 1));
-
-      if ($deprecation['reason']) {
-        $dep_parts[] = 'reason=' . $deprecation['reason'];
-      }
-
-      $response = $response->withHeader('X-' . $api_name . '-Deprecated', implode('; ', $dep_parts));
-    }
+    $response = $response->withHeader('X-' . $api_name . '-Deprecated', implode('; ', $dep_parts));
+  }
 
   $stability = $resource->getStabilityForMethod($method);
   $response  = $response->withHeader('X-' . $api_name . '-Stability', $stability);

--- a/restapi.module
+++ b/restapi.module
@@ -281,9 +281,9 @@ function restapi_page_callback(ResourceConfigurationInterface $resource) {
 
   global $user;
 
-  $request  = restapi_get_request();
-  $path     = current_path();
-  $auth     = $resource->invokeAuthenticationService($user, $request);
+  $request = restapi_get_request();
+  $path    = current_path();
+  $auth    = $resource->invokeAuthenticationService($user, $request);
 
   try {
     $account = $auth->authenticate();

--- a/restapi.module
+++ b/restapi.module
@@ -283,12 +283,7 @@ function restapi_page_callback(ResourceConfigurationInterface $resource) {
 
   $request  = restapi_get_request();
   $path     = current_path();
-
-  if (!$resource) {
-    return MENU_NOT_FOUND;
-  }
-
-  $auth = $resource->invokeAuthenticationService($user, $request);
+  $auth     = $resource->invokeAuthenticationService($user, $request);
 
   try {
     $account = $auth->authenticate();

--- a/restapi.module
+++ b/restapi.module
@@ -284,6 +284,11 @@ function restapi_page_callback(ResourceConfigurationInterface $resource) {
   $request  = restapi_get_request();
   $path     = current_path();
   $resource = restapi_get_resource($path);
+
+  if (!$resource) {
+    return MENU_NOT_FOUND;
+  }
+
   $auth     = $resource->invokeAuthenticationService($user, $request);
 
   try {

--- a/src/ResourceConfiguration.php
+++ b/src/ResourceConfiguration.php
@@ -224,11 +224,6 @@ class ResourceConfiguration implements ResourceConfigurationInterface {
   public function getDeprecationForMethod($method) {
     $class = new ReflectionClass($this->getClass());
 
-    if (!$class->hasMethod($method)) {
-      $message = sprintf('The %s method does not exist for the class %s', $method, $class);
-      throw new ClassMethodNotValidException($message);
-    }
-
     $doc_comment = $class->getMethod($method)->getDocComment();
     $deprecated  = preg_match('/\* @deprecated(?:\h+(?:[vV]?([0-9]+))?)?(?:\h+(.*)?)?$/m', $doc_comment, $matches);
 
@@ -250,11 +245,6 @@ class ResourceConfiguration implements ResourceConfigurationInterface {
   public function getStabilityForMethod($method) {
 
     $class = new ReflectionClass($this->getClass());
-
-    if (!$class->hasMethod($method)) {
-      $message = sprintf('The %s method does not exist for the class %s', $method, $class);
-      throw new ClassMethodNotValidException($message);
-    }
 
     $doc_comment = $class->getMethod($method)->getDocComment();
     $stability   = preg_match('/\* @stability\h+(.*)/m', $doc_comment, $matches);

--- a/src/ResourceConfiguration.php
+++ b/src/ResourceConfiguration.php
@@ -224,6 +224,10 @@ class ResourceConfiguration implements ResourceConfigurationInterface {
   public function getDeprecationForMethod($method) {
     $class = new ReflectionClass($this->getClass());
 
+    if (!$class->hasMethod($method)) {
+      return NULL;
+    }
+
     $doc_comment = $class->getMethod($method)->getDocComment();
     $deprecated  = preg_match('/\* @deprecated(?:\h+(?:[vV]?([0-9]+))?)?(?:\h+(.*)?)?$/m', $doc_comment, $matches);
 
@@ -245,6 +249,10 @@ class ResourceConfiguration implements ResourceConfigurationInterface {
   public function getStabilityForMethod($method) {
 
     $class = new ReflectionClass($this->getClass());
+
+    if (!$class->hasMethod($method)) {
+      return NULL;
+    }
 
     $doc_comment = $class->getMethod($method)->getDocComment();
     $stability   = preg_match('/\* @stability\h+(.*)/m', $doc_comment, $matches);

--- a/tests/ResourceConfigurationTest.php
+++ b/tests/ResourceConfigurationTest.php
@@ -133,6 +133,18 @@ class ResourceConfigurationTest extends PHPUnit_Framework_TestCase {
 
 
   /**
+   * Ensures getDeprecationForMethod() returns null if the method does not exist.
+   *
+   */
+  public function testGetDeprecationForMethodReturnsNullForInvalidMethod() {
+
+    $config = new ResourceConfiguration('path/to/resource', 'my_module', MockAnnotatedResource::class, $this->auth);
+
+    $this->assertNull($config->getDeprecationForMethod('invalidMethod'));
+  }
+
+
+  /**
    * Ensures stability parsing works as expected.
    *
    * @dataProvider stabilityAnnotationProvider
@@ -143,6 +155,18 @@ class ResourceConfigurationTest extends PHPUnit_Framework_TestCase {
     $config = new ResourceConfiguration('path/to/resource', 'my_module', MockAnnotatedResource::class, $this->auth);
 
     $this->assertEquals($stability, $config->getStabilityForMethod($method));
+  }
+
+
+  /**
+   * Ensures getStabilityForMethod() returns null if the method does not exist.
+   *
+   */
+  public function testGetStabilityForMethodReturnsNullForInvalidMethod() {
+
+    $config = new ResourceConfiguration('path/to/resource', 'my_module', MockAnnotatedResource::class, $this->auth);
+
+    $this->assertNull($config->getDeprecationForMethod('invalidMethod'));
   }
 
 

--- a/tests/ResourceConfigurationTest.php
+++ b/tests/ResourceConfigurationTest.php
@@ -133,20 +133,6 @@ class ResourceConfigurationTest extends PHPUnit_Framework_TestCase {
 
 
   /**
-   * Ensures getDeprecationForMethod() throws an exception if the method does not exist.
-   *
-   * @expectedException \Drupal\restapi\Exception\ClassMethodNotValidException
-   *
-   */
-  public function testGetDeprecationForMethodThrowsExceptionForInvalidMethod() {
-
-    $config = new ResourceConfiguration('path/to/resource', 'my_module', MockAnnotatedResource::class, $this->auth);
-
-    $this->assertNull($config->getDeprecationForMethod('invalidMethod'));
-  }
-
-
-  /**
    * Ensures stability parsing works as expected.
    *
    * @dataProvider stabilityAnnotationProvider
@@ -157,20 +143,6 @@ class ResourceConfigurationTest extends PHPUnit_Framework_TestCase {
     $config = new ResourceConfiguration('path/to/resource', 'my_module', MockAnnotatedResource::class, $this->auth);
 
     $this->assertEquals($stability, $config->getStabilityForMethod($method));
-  }
-
-
-  /**
-   * Ensures getStabilityForMethod() throws an exception if the method does not exist.
-   *
-   * @expectedException \Drupal\restapi\Exception\ClassMethodNotValidException
-   *
-   */
-  public function testGetStabilityForMethodThrowsExceptionForInvalidMethod() {
-
-    $config = new ResourceConfiguration('path/to/resource', 'my_module', MockAnnotatedResource::class, $this->auth);
-
-    $this->assertNull($config->getDeprecationForMethod('invalidMethod'));
   }
 
 


### PR DESCRIPTION
Added a ClassMethodNotValidException to the restapi and removed two of the same exceptions from ResourceConfiguration.php