### PR TITLE
Prevent presenting download/binary files as text.

### DIFF
--- a/restapi.module
+++ b/restapi.module
@@ -744,28 +744,10 @@ function _restapi_get_versioned_method(ResourceConfigurationInterface $resource,
  */
 function _restapi_is_download_response(ResponseInterface $response) {
 
-  $is_download = FALSE;
-
-  // If this content transfer encoding is a binary file, then this is a download.
-  $content_encoding = array_map('strtolower', $response->getHeader('Content-Transfer-Encoding'));
-  if (in_array('binary', $content_encoding)) {
-    $is_download = TRUE;
-  }
-
-  // If content disposition specifies an attachment, then this is a download.
+  // @see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
   $content_disposition = array_filter($response->getHeader('Content-Disposition'), function ($header) {
     return strpos(strtolower($header), 'attachment') !== FALSE;
   });
 
-  if (!empty($content_disposition)) {
-    $is_download = TRUE;
-  }
-
-  // If content description specifies file transfer then this is a download.
-  $content_description = array_map('strtolower', $response->getHeader('Content-Description'));
-  if (in_array('file transfer', $content_description)) {
-    $is_download = TRUE;
-  }
-
-  return $is_download;
+  return !empty($content_disposition);
 }

--- a/restapi.module
+++ b/restapi.module
@@ -387,8 +387,9 @@ function restapi_delivery_callback($response) {
 
   // For requests in the browser, we'll try to show the output in a more
   // pleasant way.
-  $accept = $request->getHeaderLine('Accept');
-  if ($accept) {
+  $accept      = $request->getHeaderLine('Accept');
+  $is_download = _restapi_is_download_response($response);
+  if ($accept && !$is_download) {
 
     $negotiator = new Negotiator();
     $priorities = ['application/json', 'text/html'];
@@ -728,4 +729,43 @@ function _restapi_get_versioned_method(ResourceConfigurationInterface $resource,
   }
 
   return method_exists($resource->getClass(), $method) ? $method : NULL;
+}
+
+
+/**
+ * Helper function to determine whether the response is a file download.
+ *
+ * @param ResponseInterface $response
+ *   The response.
+ *
+ * @return boolean
+ *   Returns TRUE when the response is a download, FALSE otherwise.
+ *
+ */
+function _restapi_is_download_response(ResponseInterface $response) {
+
+  $is_download = FALSE;
+
+  // If this content transfer encoding is a binary file, then this is a download.
+  $content_encoding = array_map('strtolower', $response->getHeader('Content-Transfer-Encoding'));
+  if (in_array('binary', $content_encoding)) {
+    $is_download = TRUE;
+  }
+
+  // If content disposition specifies an attachment, then this is a download.
+  $content_disposition = array_filter($response->getHeader('Content-Disposition'), function ($header) {
+    return strpos(strtolower($header), 'attachment') !== FALSE;
+  });
+
+  if (!empty($content_disposition)) {
+    $is_download = TRUE;
+  }
+
+  // If content description specifies file transfer then this is a download.
+  $content_description = array_map('strtolower', $response->getHeader('Content-Description'));
+  if (in_array('file transfer', $content_description)) {
+    $is_download = TRUE;
+  }
+
+  return $is_download;
 }

--- a/restapi.module
+++ b/restapi.module
@@ -389,7 +389,7 @@ function restapi_delivery_callback($response) {
   // pleasant way.
   $accept      = $request->getHeaderLine('Accept');
   // @see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
-  $is_download = stripos($request->getHeaderLine('Content-Disposition'), 'attachment') !== FALSE;
+  $is_download = stripos($response->getHeaderLine('Content-Disposition'), 'attachment') !== FALSE;
   if ($accept && !$is_download) {
 
     $negotiator = new Negotiator();

--- a/restapi.module
+++ b/restapi.module
@@ -388,7 +388,8 @@ function restapi_delivery_callback($response) {
   // For requests in the browser, we'll try to show the output in a more
   // pleasant way.
   $accept      = $request->getHeaderLine('Accept');
-  $is_download = _restapi_is_download_response($response);
+  // @see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
+  $is_download = stripos($request->getHeaderLine('Content-Disposition'), 'attachment') !== FALSE;
   if ($accept && !$is_download) {
 
     $negotiator = new Negotiator();
@@ -729,25 +730,4 @@ function _restapi_get_versioned_method(ResourceConfigurationInterface $resource,
   }
 
   return method_exists($resource->getClass(), $method) ? $method : NULL;
-}
-
-
-/**
- * Helper function to determine whether the response is a file download.
- *
- * @param ResponseInterface $response
- *   The response.
- *
- * @return boolean
- *   Returns TRUE when the response is a download, FALSE otherwise.
- *
- */
-function _restapi_is_download_response(ResponseInterface $response) {
-
-  // @see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
-  $content_disposition = array_filter($response->getHeader('Content-Disposition'), function ($header) {
-    return strpos(strtolower($header), 'attachment') !== FALSE;
-  });
-
-  return !empty($content_disposition);
 }


### PR DESCRIPTION
This patch checks the response headers for clues that it's a file attachment or a binary file which should never be presented as text content.