### PR TITLE
Remove watchdog notice for version fallback

### DIFF
--- a/restapi.module
+++ b/restapi.module
@@ -717,7 +717,6 @@ function _restapi_get_versioned_method(ResourceConfigurationInterface $resource,
     $version = $current_version > $request->getVersion() ? $request->getVersion() : $current_version;
   }
   else {
-    watchdog('restapi', 'Accept header does not include a requested version, falling back to current version.', [], WATCHDOG_INFO);
     $version = $current_version;
   }
 


### PR DESCRIPTION
Because this check is done multiple times in a request, this watchdog message just clogs up the log. Falling back to the default version is a normal occurrence that doesn't typically require additional logging.