### PR TITLE
Only pretty print the response body if the content type is JSON

### DIFF
--- a/restapi.module
+++ b/restapi.module
@@ -390,7 +390,8 @@ function restapi_delivery_callback($response) {
   $accept      = $request->getHeaderLine('Accept');
   // @see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
   $is_download = stripos($response->getHeaderLine('Content-Disposition'), 'attachment') !== FALSE;
-  if ($accept && !$is_download) {
+  $is_json     = $response->getHeaderLine('Content-Type') === 'application/json';
+  if ($accept && !$is_download && $is_json) {
 
     $negotiator = new Negotiator();
     $priorities = ['application/json', 'text/html'];

--- a/restapi.module
+++ b/restapi.module
@@ -390,7 +390,7 @@ function restapi_delivery_callback($response) {
   $accept      = $request->getHeaderLine('Accept');
   // @see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
   $is_download = stripos($response->getHeaderLine('Content-Disposition'), 'attachment') !== FALSE;
-  $is_json     = $response->getHeaderLine('Content-Type') === 'application/json';
+  $is_json     = preg_match('/^application\/json\+?/', $response->getHeaderLine('Content-Type'));
   if ($accept && !$is_download && $is_json) {
 
     $negotiator = new Negotiator();


### PR DESCRIPTION
This allows restapi to serve non-JSON data in browser contexts. An example use case is allowing restapi to serve images that can be directly used in the browser.