### PR TITLE
Fix JSON content type matching

### DIFF
--- a/restapi.module
+++ b/restapi.module
@@ -388,9 +388,16 @@ function restapi_delivery_callback($response) {
   // For requests in the browser, we'll try to show the output in a more
   // pleasant way.
   $accept      = $request->getHeaderLine('Accept');
+
   // @see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
   $is_download = stripos($response->getHeaderLine('Content-Disposition'), 'attachment') !== FALSE;
-  $is_json     = preg_match('/^application\/(?:(?:.+)\+){0,1}json$/', $response->getHeaderLine('Content-Type'));
+
+  // Only display JSON responses in this manner.
+  $is_json = preg_match('/^application\/(?:(?:.+)\+){0,1}json$/', $response->getHeaderLine('Content-Type'));
+
+  // Even though it's incorrect, support the common form of application/json+hal
+  $is_json = $is_json || $respponse->getHeaderLine('Content-Type') === 'application/json+hal';
+
   if ($accept && !$is_download && $is_json) {
 
     $negotiator = new Negotiator();

--- a/restapi.module
+++ b/restapi.module
@@ -390,7 +390,7 @@ function restapi_delivery_callback($response) {
   $accept      = $request->getHeaderLine('Accept');
   // @see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
   $is_download = stripos($response->getHeaderLine('Content-Disposition'), 'attachment') !== FALSE;
-  $is_json     = preg_match('/^application\/json\+?/', $response->getHeaderLine('Content-Type'));
+  $is_json     = preg_match('/^application\/(?:(?:.+)\+){0,1}json$/', $response->getHeaderLine('Content-Type'));
   if ($accept && !$is_download && $is_json) {
 
     $negotiator = new Negotiator();


### PR DESCRIPTION
Fixes the regexp to match if the content type is JSON. [According to the IANA](
https://www.iana.org/assignments/media-types/media-types.xhtm), `json` always comes last in the mimetype identifier.

Test:

```php
$tests[] = 'application/json';                // true
$tests[] = 'application/+json';               // false
$tests[] = 'application/hal+json';            // true
$tests[] = 'application/json+hal';            // false
$tests[] = 'application/notjson';             // false
$tests[] = 'application/haljson+json';        // true
$tests[] = 'application/json+haljson+json';   // true


$pattern = '/^application\/(?:(?:.+)\+){0,1}json$/';

foreach ($tests as $test) {
    var_dump(preg_match($pattern, $test) == true);
}
```